### PR TITLE
docs: Add prerequisites for installing pycairo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,28 @@ Thank you for considering a contribution! This guide helps you set up a dev envi
 - Use Python 3.9+.
 - We recommend `uv` for environment and dependency management, but `pip` works too.
 
+### Prerequisites
+
+Before you can install the project, you need the necessary system libraries for our dependencies.
+
+**On macOS (using Homebrew):**
+```bash
+brew install cairo pkg-config
+```
+
+On Debian/Ubuntu Linux:
+```bash
+sudo apt-get install libcairo2-dev pkg-config
+```
+
+On Fedora/CentOS Linux:
+```bash
+sudo dnf install cairo-devel pkg-config
+```
+
+### Installation
+
+Now you can clone the repository and install the Python packages.
 ```bash
 # Clone
 git clone https://github.com/MontaQLabs/DotMotion.git


### PR DESCRIPTION
## **Docs: Add System Prerequisites to Fix `pycairo` Build Failure**

Hi there!

I ran into a build error while setting up the development environment on my machine and wanted to submit a fix to the documentation to help future contributors have a smoother experience.

This PR adds a new "Prerequisites" section to the `CONTRIBUTING.md` file.

## The Problem

When following the current setup instructions, the `uv pip install -e .` command fails with an error when trying to build the `pycairo` package. The build process can't find the necessary C libraries (`cairo` and `pkg-config`) on the system, which causes the installation to stop.

### How to Reproduce the Error

1.  Follow the instructions in `CONTRIBUTING.md` on a fresh macOS or Linux system that does not have the Cairo library pre-installed.
2.  Clone the repository.
3.  Run `uv venv` and `uv pip install -e .`.
4.  The installation will fail with the `Failed to build pycairo` error.

**Here is a screenshot of the error I encountered:**

<img width="1385" height="335" alt="Screenshot 2025-10-03 at 2 04 01 PM" src="https://github.com/user-attachments/assets/ec7b7a41-6cf4-4ecb-9531-30cafd923ef7" />


## The Solution

This PR updates the `CONTRIBUTING.md` file to include a **"Prerequisites"** section *before* the installation steps. This new section provides the commands to install the necessary system libraries (`cairo` and `pkg-config`) for macOS, Debian/Ubuntu, and Fedora/CentOS.

For me specificly I had to do: 
```bash
brew install cairo pkg-config
```

**Here is a screenshot of the installation succeeding after the fix:**

<img width="1127" height="201" alt="Screenshot 2025-10-03 at 2 07 08 PM" src="https://github.com/user-attachments/assets/1c0d1632-57d9-4849-bf44-281f51faefda" />

This small change should help new contributors get up and running without any issues. Hope this helps! 😊